### PR TITLE
fix crd customization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- bases/role.yaml


### PR DESCRIPTION
`make install` fails probably due to kustomization file missing. This PR adds it.

Before

```
❯ make install
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
/Users/ashith/git/ashithwilson/istio-fortsa/bin/controller-gen-v0.14.0 rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
Downloading sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
/Users/ashith/git/ashithwilson/istio-fortsa/bin/kustomize-v5.3.0 build config/crd | kubectl apply -f -
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/ashith/git/ashithwilson/istio-fortsa/config/crd'
error: no objects passed to apply
make: *** [install] Error 1
```

After
```
❯ make install
/Users/ashith/git/ashithwilson/istio-fortsa/bin/controller-gen-v0.14.0 rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/ashith/git/ashithwilson/istio-fortsa/bin/kustomize-v5.3.0 build config/crd | kubectl apply -f -
clusterrole.rbac.authorization.k8s.io/manager-role created
```