### PR TITLE
Update _helpers.tpl to allow users to use a custom image.

### DIFF
--- a/chart/fortsa/templates/_helpers.tpl
+++ b/chart/fortsa/templates/_helpers.tpl
@@ -14,8 +14,8 @@
 
 
 {{- define "chart.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if or .Values.appVersion .Chart.AppVersion -}}
+app.kubernetes.io/version: {{ .Values.appVersion | default .Chart.AppVersion | quote }}
 {{- end }}
 {{- if .Chart.Version }}
 helm.sh/chart: {{ .Chart.Version | quote }}


### PR DESCRIPTION
When building a custom Fortsa image, specifying an image version different from the default is required.