### PR TITLE
Potential fix for code scanning alert no. 5: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/test/utils/istio.go
+++ b/test/utils/istio.go
@@ -56,7 +56,15 @@ func VersionToRevision(version string) string {
 
 // extractTarEntry extracts a single tar entry to tmpDir, skipping path-traversal entries.
 func extractTarEntry(tarReader *tar.Reader, header *tar.Header, tmpDir, absTmpDir string) error {
-	target := filepath.Join(tmpDir, header.Name)
+	entryName := filepath.Clean(header.Name)
+	if entryName == "." || entryName == "" || filepath.IsAbs(entryName) {
+		return nil
+	}
+	if entryName == ".." || strings.HasPrefix(entryName, ".."+string(os.PathSeparator)) {
+		return nil
+	}
+
+	target := filepath.Join(tmpDir, entryName)
 	var err error
 	target, err = filepath.Abs(target)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/istio-ecosystem/fortsa/security/code-scanning/5](https://github.com/istio-ecosystem/fortsa/security/code-scanning/5)

Use a strict archive-entry path validation step before constructing the output path used by filesystem operations.

Best fix in this file:
1. In `extractTarEntry`, validate `header.Name` directly:
   - reject empty names,
   - reject absolute paths (`filepath.IsAbs`),
   - clean path (`filepath.Clean`) and reject `".."` or paths beginning with `"../"` (OS separator-aware).
2. Use the cleaned entry name to build `target`.
3. Keep the existing `Abs` + `Rel` boundary check as a second safety layer.
4. Optionally skip unsupported typeflags; no functional change needed for current behavior.

This keeps existing behavior (extract valid dir/regular-file entries under `tmpDir`) while preventing traversal and satisfying CodeQL for all three variants tied to the same taint flow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
